### PR TITLE
Update to new air quality mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^1.0.1",
     "async-lock": "^1.4.1",
-    "winix-api": "1.5.5"
+    "winix-api": "1.6.2"
   },
   "devDependencies": {
     "@types/async-lock": "^1.4.2",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -495,8 +495,6 @@ export class WinixPurifierAccessory {
     switch (airQuality) {
       case AirQuality.Good:
         return this.Characteristic.AirQuality.GOOD;
-      case AirQuality.GoodAlternate:
-        return this.Characteristic.AirQuality.GOOD;
       case AirQuality.Fair:
         return this.Characteristic.AirQuality.FAIR;
       case AirQuality.Poor:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3684,10 +3684,10 @@ why-is-node-running@^2.3.0:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-winix-api@1.5.5:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/winix-api/-/winix-api-1.5.5.tgz#ade63683e9f2f87fddb1df827ecf18eb526f7c88"
-  integrity sha512-opzE/eVbZ1ofoF8Tnb+S2VK9aH4zKaVHCbbESYLu4GF8ZnjkJUdGMrwT1acT1ob2xdsnXFeAqFzrEo9yPZUHww==
+winix-api@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/winix-api/-/winix-api-1.6.2.tgz#3c99bfc74e133fa269135cb7c2c51c15765819b8"
+  integrity sha512-otPw+lBUpwBDYQMzfs/Xb6dAVIl5dNQKkmNUYKwcuudf3dIP9o6Lue0M7oYdgOCGCcEsOb2oinmJxsPYl6SRCQ==
   dependencies:
     "@aws-sdk/client-cognito-identity-provider" "3.716.0"
     axios "1.7.9"


### PR DESCRIPTION
Resolves #25 

Winix is now sometimes returning a number from `1.0` - `3.0` for the air quality, instead of just the `01`, `02`, `03` static values. This provides the mapping for both by updating the underlying [winix-api](https://github.com/regaw-leinad/winix-api) library