### PR TITLE
fix: stop leaking polling loops on device refresh

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -117,7 +117,12 @@ export class WinixPurifierPlatform implements DynamicPlatformPlugin {
       let accessory = this.accessories.get(uuid);
       this.log.debug('Found', accessory ? 'existing' : 'new', 'accessory:', this.logName(device));
 
-      if (accessory) {
+      if (accessory && this.handlers.has(uuid)) {
+        // Existing device on refresh: update metadata only, keep handler + polling loop
+        accessory.context.device = device;
+        this.api.updatePlatformAccessories([accessory]);
+      } else if (accessory) {
+        // First boot with cached accessory: create handler
         accessory.context.device = device;
         const handler = await this.createNewAccessoryHandler(accessory, devices.length);
         this.handlers.set(uuid, handler);


### PR DESCRIPTION
## Summary

- Skip handler recreation for existing devices during periodic device refresh
- Prevents polling loop accumulation that causes rate limit exhaustion

## Problem

`discoverDevices()` runs on a configurable interval (default: every 60 minutes) to pick up new/removed devices. For **existing** devices, it was calling `createNewAccessoryHandler()` every cycle, which creates a new `WinixPurifierAccessory` -> new `Device` -> `startPolling()`. The old `Device`'s `setTimeout` chain was never stopped (no `stopPolling()` call), so it kept running indefinitely.

After N hours with M devices, there are `M + (N * M)` parallel polling loops. With 4 devices after 5 hours, that's 24 concurrent loops hammering the API, quickly exhausting the rate limit bucket and causing the "death spiral" reported in #39.

## Fix

When `discoverDevices()` encounters an existing device that already has a handler, just update the accessory metadata and skip handler recreation entirely. Handlers only need to be created on first boot (for cached accessories restored by Homebridge) or when a genuinely new device appears.

## Why

The hourly refresh exists to discover new devices added to (or removed from) the Winix account. Existing devices don't need their handlers, services, or polling loops recreated. The device metadata (`deviceAlias`, `mcuVer`) is updated on the accessory context, which is all that's needed.

`removeOldDevices()` already correctly calls `stopPolling()` for removed devices. The gap was only in the existing-device path.

Related: #39
