### PR TITLE
fix: upgrade winix-api to 2.0.0 for control plane URL fix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: Integration Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * 0' # Sunday at 7am UTC
+    - cron: '30 6 * * *' # Daily at 6:30am UTC (30 min after winix-api)
 
 jobs:
   integration:
@@ -37,4 +37,6 @@ jobs:
       - name: Run rate limit integration tests
         run: yarn test:integration:rate-limit
         env:
+          WINIX_USERNAME: ${{ secrets.WINIX_USERNAME }}
+          WINIX_PASSWORD: ${{ secrets.WINIX_PASSWORD }}
           WINIX_DEVICE_ID: ${{ secrets.WINIX_DEVICE_ID }}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   ],
   "dependencies": {
     "@homebridge/plugin-ui-utils": "1.0.3",
-    "winix-api": "1.9.0"
+    "winix-api": "2.0.0"
   },
   "devDependencies": {
     "@types/node": "20.11.0",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -34,7 +34,7 @@ export class WinixPurifierPlatform implements DynamicPlatformPlugin {
   private readonly accessories: Map<string, PlatformAccessory<DeviceContext>>;
   private readonly handlers: Map<string, WinixPurifierAccessory>;
   private readonly deviceOverrides: Map<string, DeviceOverride>;
-  readonly client: WinixClient;
+  client!: WinixClient;
   private winix: WinixHandler;
 
   constructor(
@@ -47,7 +47,6 @@ export class WinixPurifierPlatform implements DynamicPlatformPlugin {
     this.handlers = new Map<string, WinixPurifierAccessory>();
     this.deviceOverrides = (this.config.deviceOverrides ?? [])
       .reduce((m, o) => m.set(o.deviceId, o), new Map<string, DeviceOverride>());
-    this.client = new WinixClient();
     this.winix = new WinixHandler(api.user.storagePath(), ENCRYPTION_KEY);
 
     this.api.on(APIEvent.DID_FINISH_LAUNCHING, this.onFinishLaunching.bind(this));
@@ -80,6 +79,8 @@ export class WinixPurifierPlatform implements DynamicPlatformPlugin {
       this.log.error('error getting devices:', e.message);
       return;
     }
+
+    this.client = new WinixClient(this.winix.getIdentityId());
 
     await this.discoverDevices();
 

--- a/src/winix.ts
+++ b/src/winix.ts
@@ -108,6 +108,13 @@ export class WinixHandler {
     }
   }
 
+  getIdentityId(): string {
+    if (!this.winix) {
+      throw new UnauthenticatedError();
+    }
+    return this.winix.getIdentityId();
+  }
+
   async getDevices(): Promise<WinixDevice[]> {
     if (!this.winix || !this.auth) {
       throw new UnauthenticatedError();

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -56,7 +56,7 @@ describe('Device', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
-    client = new WinixClient();
+    client = new WinixClient('us-east-1:test-identity-id');
     device = new Device(DEVICE_ID, POLL_INTERVAL_MS, mockLog, client);
   });
 

--- a/tests/integration/integration-rate-limit.test.ts
+++ b/tests/integration/integration-rate-limit.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { Power, WinixClient, RateLimitError } from 'winix-api';
 import { Device } from '../../src/device';
+import { WinixHandler } from '../../src/winix';
+import { ENCRYPTION_KEY } from '../../src/settings';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
+const USERNAME = process.env.WINIX_USERNAME;
+const PASSWORD = process.env.WINIX_PASSWORD;
 const DEVICE_ID = process.env.WINIX_DEVICE_ID;
+const canRun = !!(USERNAME && PASSWORD && DEVICE_ID);
 
 interface LogEntry {
   level: string;
@@ -61,13 +69,19 @@ async function drainBucket(client: WinixClient, deviceId: string): Promise<numbe
   return requestCount;
 }
 
-describe.runIf(DEVICE_ID)('rate limiting integration', () => {
+describe.runIf(canRun)('rate limiting integration', () => {
   // Tests 1 and 2 share a pre-drained client (efficient, no recovery wait needed).
   // Test 3 uses its own client so it can do initialFetch before draining.
   let drainedClient: WinixClient;
+  let identityId: string;
 
   beforeAll(async () => {
-    drainedClient = new WinixClient();
+    const storagePath = await mkdtemp(path.join(tmpdir(), 'winix-rate-limit-'));
+    const handler = new WinixHandler(storagePath, ENCRYPTION_KEY);
+    await handler.login(USERNAME!, PASSWORD!);
+    identityId = handler.getIdentityId();
+
+    drainedClient = new WinixClient(identityId);
     const count = await drainBucket(drainedClient, DEVICE_ID!);
     console.log(`Drained bucket after ${count} requests`);
     expect(drainedClient.getCooldownRemaining()).toBeGreaterThan(0);
@@ -105,12 +119,12 @@ describe.runIf(DEVICE_ID)('rate limiting integration', () => {
     // 5. Wait for recovery (poll, don't guess)
     // 6. Verify polling delivered updates
     const { log, hasMessageContaining } = createTestLogger();
-    const client = new WinixClient();
+    const client = new WinixClient(identityId);
     const device = new Device(DEVICE_ID!, 5_000, log, client);
 
     // Step 1: Wait for API to recover from earlier tests.
     // AWS WAF recovery timing is unpredictable, so poll instead of guessing.
-    const probeClient = new WinixClient();
+    const probeClient = new WinixClient(identityId);
     console.log('Waiting for API to recover from earlier tests...');
     await waitForRecovery(probeClient, DEVICE_ID!);
 

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -73,7 +73,7 @@ describe.runIf(hasCredentials)('plugin integration', () => {
     });
 
     it('should fetch device status on initialFetch', async () => {
-      client = new WinixClient();
+      client = new WinixClient(handler.getIdentityId());
       device = new Device(DEVICE_ID!, 30_000, log, client);
 
       await device.initialFetch();
@@ -88,7 +88,7 @@ describe.runIf(hasCredentials)('plugin integration', () => {
     }, 15_000);
 
     it('should receive updates via polling', async () => {
-      client = new WinixClient();
+      client = new WinixClient(handler.getIdentityId());
       device = new Device(DEVICE_ID!, 5_000, log, client);
       await device.initialFetch();
 
@@ -104,7 +104,7 @@ describe.runIf(hasCredentials)('plugin integration', () => {
     }, 25_000);
 
     it('should work with shared WinixClient across two devices', async () => {
-      client = new WinixClient();
+      client = new WinixClient(handler.getIdentityId());
       const device1 = new Device(DEVICE_ID!, 5_000, log, client);
       const device2 = new Device(DEVICE_ID!, 7_000, log, client);
 

--- a/tests/winix.test.ts
+++ b/tests/winix.test.ts
@@ -133,6 +133,20 @@ describe('WinixHandler', () => {
     });
   });
 
+  describe('getIdentityId', () => {
+    it('should throw UnauthenticatedError if winix is not authenticated', () => {
+      expect(() => handler.getIdentityId()).toThrow(UnauthenticatedError);
+    });
+
+    it('should return the identityId from WinixAccount when authenticated', () => {
+      handler['winix'] = {
+        getIdentityId: vi.fn().mockReturnValue('us-east-1:abc-123'),
+      } as unknown as WinixAccount;
+
+      expect(handler.getIdentityId()).toBe('us-east-1:abc-123');
+    });
+  });
+
   describe('getDevices', () => {
     it('should throw UnauthenticatedError if winix is not authenticated', async () => {
       await expect(handler.getDevices()).rejects.toThrow(UnauthenticatedError);

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,6 +93,51 @@
     "@smithy/util-utf8" "^4.2.2"
     tslib "^2.6.2"
 
+"@aws-sdk/client-cognito-identity@3.1014.0":
+  version "3.1014.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1014.0.tgz#1dbc892fdc970bf06d8fc4a9e52cc2d88551b196"
+  integrity sha512-NvNThzNvdKigwy9gNQnipeefydZ1HGU1kReXl5FPMxclzNgYB0IzwmJSW0mXICdd7PWARUblcfz72LeoOyXs0A==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.973.23"
+    "@aws-sdk/credential-provider-node" "^3.972.24"
+    "@aws-sdk/middleware-host-header" "^3.972.8"
+    "@aws-sdk/middleware-logger" "^3.972.8"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.8"
+    "@aws-sdk/middleware-user-agent" "^3.972.24"
+    "@aws-sdk/region-config-resolver" "^3.972.9"
+    "@aws-sdk/types" "^3.973.6"
+    "@aws-sdk/util-endpoints" "^3.996.5"
+    "@aws-sdk/util-user-agent-browser" "^3.972.8"
+    "@aws-sdk/util-user-agent-node" "^3.973.10"
+    "@smithy/config-resolver" "^4.4.13"
+    "@smithy/core" "^3.23.12"
+    "@smithy/fetch-http-handler" "^5.3.15"
+    "@smithy/hash-node" "^4.2.12"
+    "@smithy/invalid-dependency" "^4.2.12"
+    "@smithy/middleware-content-length" "^4.2.12"
+    "@smithy/middleware-endpoint" "^4.4.27"
+    "@smithy/middleware-retry" "^4.4.44"
+    "@smithy/middleware-serde" "^4.2.15"
+    "@smithy/middleware-stack" "^4.2.12"
+    "@smithy/node-config-provider" "^4.3.12"
+    "@smithy/node-http-handler" "^4.5.0"
+    "@smithy/protocol-http" "^5.3.12"
+    "@smithy/smithy-client" "^4.12.7"
+    "@smithy/types" "^4.13.1"
+    "@smithy/url-parser" "^4.2.12"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-body-length-node" "^4.2.3"
+    "@smithy/util-defaults-mode-browser" "^4.3.43"
+    "@smithy/util-defaults-mode-node" "^4.2.47"
+    "@smithy/util-endpoints" "^3.3.3"
+    "@smithy/util-middleware" "^4.2.12"
+    "@smithy/util-retry" "^4.2.12"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
 "@aws-sdk/core@^3.973.23":
   version "3.973.23"
   resolved "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.23.tgz"
@@ -3518,11 +3563,12 @@ why-is-node-running@^2.3.0:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-winix-api@1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/winix-api/-/winix-api-1.9.0.tgz#e923528e7a0a0bfb204963b528688a265584317e"
-  integrity sha512-UTyYboavNdqtpoR2qINGaT220tP3r+lt3RF/3PbLq1nS18vIO1LFVPNPqVEHid1rbUhQbxIpiHfHaUDP9Tgw8Q==
+winix-api@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/winix-api/-/winix-api-2.0.0.tgz#dce9ce22083a44615ab9430494728d4ffe267186"
+  integrity sha512-3oaV3X89Ul93rQePDiTXdFzJ4j/4vbTenaaltr5kGsppAQuByj/YMUqxpYN0KSN5zNDuRfhola8CUhx0GWK2jg==
   dependencies:
+    "@aws-sdk/client-cognito-identity" "3.1014.0"
     "@aws-sdk/client-cognito-identity-provider" "3.1014.0"
     axios "1.13.6"
     crc "4.3.2"


### PR DESCRIPTION
Ref #41

## Summary
- Upgrade `winix-api` dep from 1.9.0 to 2.0.0 (instance-based client, identityId in control URLs)
- Defer `WinixClient` construction in `WinixPurifierPlatform` until after auth resolves
- Add `WinixHandler.getIdentityId()` passthrough for the plugin and tests
- Switch integration tests CI to daily (6:30 UTC, 30 min after `winix-api`)

## Problem
Winix rotated their mobile app (v1.5.7) and broke the plugin in two ways, both covered by #41:

1. Login flow. They rotated the Cognito user pool client and auth endpoints, so existing sessions stopped working. That half was already fixed in prior `winix-api` releases.
2. Device control. The old control URL segment `/A211/` stopped applying commands. The API returned 200 but the device ignored the request, so power/mode/airflow/plasmawave setters all silently no-oped.

This PR picks up the last missing piece: the control URL fix in `winix-api` 2.0.0.

## Fix
`winix-api` 2.0.0 switches to `/common/control/devices/{deviceId}/{identityId}/{cmd}` and makes `WinixClient` instance-based. This PR wires the `identityId` through the plugin:

- `WinixHandler` gains a small `getIdentityId()` passthrough (throws `UnauthenticatedError` pre-auth)
- `WinixPurifierPlatform.client` is no longer constructed in the ctor. It is created inside `onFinishLaunching` right after `winix.refresh()` succeeds, using `winix.getIdentityId()`
- All existing consumers (`Device`, accessory handlers) are unchanged. They still get a ready-to-use `WinixClient` instance

## Why
The plugin already waits for auth before doing anything device-shaped (discovery is only called after `refresh()` resolves), so deferring client construction matches existing lifecycle guarantees without needing guards at read sites.

## Verified
- Unit tests: all 70 passing (added 2 for `WinixHandler.getIdentityId()`)
- Integration tests: run locally against a real device, all 6 passing on the new library
- End-to-end: built locally, loaded into Homebridge via the existing global symlink, paired with the Home app, exercised power on/off, mode (auto/manual), and fan speed (turbo) across all 3 C545 devices. Every write landed on the device. Status polling continued clean throughout.

## Test Plan
- Rate-limit integration now requires `WINIX_USERNAME` / `WINIX_PASSWORD` (needed to resolve an `identityId`). Secrets already exist in CI