### PR TITLE
fix: recover from NoDataError and MobileSessionInvalidError

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts tests/integration/integration.test.ts --reporter=verbose",
     "test:integration:rate-limit": "vitest run --config vitest.integration.config.ts tests/integration/integration-rate-limit.test.ts --reporter=verbose",
+    "test:integration:session-recovery": "node --env-file-if-exists=.env ./node_modules/vitest/vitest.mjs run --config vitest.integration.config.ts tests/integration/integration-session-recovery.test.ts --reporter=verbose",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "validate": "yarn lint && yarn build && yarn test",
@@ -65,7 +66,7 @@
   ],
   "dependencies": {
     "@homebridge/plugin-ui-utils": "1.0.3",
-    "winix-api": "2.0.0"
+    "winix-api": "2.0.1"
   },
   "devDependencies": {
     "@types/node": "20.11.0",

--- a/src/device.ts
+++ b/src/device.ts
@@ -1,4 +1,4 @@
-import { Airflow, AirQuality, DeviceStatus, Mode, Plasmawave, Power, RateLimitError, WinixClient } from 'winix-api';
+import { Airflow, AirQuality, DeviceStatus, Mode, NoDataError, Plasmawave, Power, RateLimitError, WinixClient } from 'winix-api';
 import { DeviceLogger } from './logger';
 
 export interface DeviceState extends DeviceStatus {
@@ -210,12 +210,23 @@ export class Device {
         this.schedulePoll(this.pollIntervalMs);
         return;
       }
+      // Winix occasionally returns "no data" for a healthy device. Treat as
+      // transient: keep last-known state and don't count toward unreachable.
+      if (e instanceof NoDataError) {
+        this.log.debug('device:poll() got NoDataError, retaining last-known state');
+        this.schedulePoll(this.pollIntervalMs);
+        return;
+      }
       this.consecutiveFailures++;
       const backoffMs = Math.min(
         this.pollIntervalMs * Math.pow(2, this.consecutiveFailures),
         MAX_BACKOFF_MS,
       );
-      this.log.error(`device:poll() error: ${(e as Error).message} (retry in ${Math.round(backoffMs / 1000)}s)`);
+      const err = e as Error;
+      this.log.error(
+        `device:poll() error: ${err.constructor?.name ?? 'Error'}: ${err.message} ` +
+        `(retry in ${Math.round(backoffMs / 1000)}s)`,
+      );
       this.schedulePoll(backoffMs);
       return;
     }

--- a/src/winix.ts
+++ b/src/winix.ts
@@ -1,4 +1,11 @@
-import { RefreshTokenExpiredError, WinixAccount, WinixAuth, WinixAuthResponse, WinixDevice } from 'winix-api';
+import {
+  MobileSessionInvalidError,
+  RefreshTokenExpiredError,
+  WinixAccount,
+  WinixAuth,
+  WinixAuthResponse,
+  WinixDevice,
+} from 'winix-api';
 import { decrypt, DecryptionFailedError, encrypt } from './encryption';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { WinixPluginAuth } from './config';
@@ -6,6 +13,7 @@ import path from 'node:path';
 
 const TOKEN_DIRECTORY_NAME = 'winix-purifiers';
 const TOKEN_FILE_NAME = 'token.json';
+const MIN_RELOGIN_INTERVAL_MS = 5 * 60 * 1000;
 
 export class NotConfiguredError extends Error {
   constructor() {
@@ -23,6 +31,7 @@ export class WinixHandler {
   private readonly refreshTokenPath: string;
   private auth?: WinixPluginAuth;
   private winix?: WinixAccount;
+  private lastReloginAt = 0;
 
   constructor(storagePath: string, private readonly encryptionKey: string) {
     this.refreshTokenPath = path.join(storagePath, TOKEN_DIRECTORY_NAME, TOKEN_FILE_NAME);
@@ -125,11 +134,22 @@ export class WinixHandler {
     try {
       devices = await this.winix.getDevices();
     } catch (e: unknown) {
-      if (!(e instanceof RefreshTokenExpiredError)) {
+      if (e instanceof RefreshTokenExpiredError) {
+        await this.login(this.auth.username, this.auth.password);
+        return await this.winix.getDevices();
+      }
+
+      if (!(e instanceof MobileSessionInvalidError)) {
         throw e;
       }
 
-      // if we get a refresh token expiry, we need to re-login and get devices again
+      // Mobile session invalidated (MULTI LOGIN / "user is not valid"). Re-login
+      // is throttled to prevent ping-pong with another active session.
+      if (Date.now() - this.lastReloginAt < MIN_RELOGIN_INTERVAL_MS) {
+        throw e;
+      }
+
+      this.lastReloginAt = Date.now();
       await this.login(this.auth.username, this.auth.password);
       return await this.winix.getDevices();
     }

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Airflow, AirQuality, Mode, Plasmawave, Power, WinixClient, RateLimitError } from 'winix-api';
+import { Airflow, AirQuality, Mode, NoDataError, Plasmawave, Power, WinixClient, RateLimitError } from 'winix-api';
 import { Device } from '../src/device';
 
 vi.mock('winix-api', async () => {
@@ -18,6 +18,13 @@ vi.mock('winix-api', async () => {
     }
   }
 
+  class NoDataError extends Error {
+    constructor() {
+      super('no data (invalid or unregistered device?)');
+      this.name = 'NoDataError';
+    }
+  }
+
   const WinixClient = vi.fn().mockImplementation(() => ({
     getDeviceStatus: vi.fn(),
     setPower: vi.fn(),
@@ -26,7 +33,7 @@ vi.mock('winix-api', async () => {
     setPlasmawave: vi.fn(),
   }));
 
-  return { ...enums, WinixClient, RateLimitError };
+  return { ...enums, WinixClient, RateLimitError, NoDataError };
 });
 
 const mockLog = {
@@ -584,6 +591,43 @@ describe('Device', () => {
 
       // State should not have changed (optimistic update only happens after await succeeds)
       expect(device.getPower()).toBe(Power.On);
+    });
+  });
+
+  describe('NoDataError handling', () => {
+    it('should not increment consecutiveFailures on NoDataError during poll', async () => {
+      vi.mocked(client.getDeviceStatus).mockResolvedValue(mockStatus);
+      await device.initialFetch();
+      expect(device.isReachable()).toBe(true);
+
+      vi.mocked(client.getDeviceStatus).mockRejectedValue(new NoDataError());
+      device.startPolling(vi.fn());
+
+      // Many consecutive NoDataErrors should not flip the device to unreachable
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      }
+
+      expect(device.isReachable()).toBe(true);
+    });
+
+    it('should retain last-known state across NoDataError polls', async () => {
+      vi.mocked(client.getDeviceStatus).mockResolvedValue({
+        ...mockStatus,
+        power: Power.On,
+        airflow: Airflow.High,
+      });
+      await device.initialFetch();
+      expect(device.getPower()).toBe(Power.On);
+      expect(device.getAirflow()).toBe(Airflow.High);
+
+      vi.mocked(client.getDeviceStatus).mockRejectedValue(new NoDataError());
+      device.startPolling(vi.fn());
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+      // Last-known state retained
+      expect(device.getPower()).toBe(Power.On);
+      expect(device.getAirflow()).toBe(Airflow.High);
     });
   });
 });

--- a/tests/integration/integration-session-recovery.test.ts
+++ b/tests/integration/integration-session-recovery.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterAll, beforeAll } from 'vitest';
+import { MobileSessionInvalidError, WinixAccount, WinixClient } from 'winix-api';
+import { WinixHandler } from '../../src/winix';
+import { ENCRYPTION_KEY } from '../../src/settings';
+import { Device } from '../../src/device';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const USERNAME = process.env.WINIX_USERNAME;
+const PASSWORD = process.env.WINIX_PASSWORD;
+const DEVICE_ID = process.env.WINIX_DEVICE_ID;
+
+const hasCredentials = !!(USERNAME && PASSWORD);
+const hasDevice = hasCredentials && !!DEVICE_ID;
+
+const log = {
+  debug: (...args: unknown[]) => console.log('[DEBUG]', ...args),
+  info: (...args: unknown[]) => console.log('[INFO]', ...args),
+  warn: (...args: unknown[]) => console.log('[WARN]', ...args),
+  error: (...args: unknown[]) => console.log('[ERROR]', ...args),
+} as any;
+
+// WARNING: these tests invalidate the Winix mobile-app session on whatever
+// phone is logged in with the same account.
+
+describe.runIf(hasCredentials)('plugin session recovery', () => {
+  let storagePath: string;
+
+  beforeAll(async () => {
+    storagePath = await mkdtemp(path.join(tmpdir(), 'winix-test-'));
+  });
+
+  afterAll(async () => {
+    await rm(storagePath, { recursive: true, force: true });
+  });
+
+  describe.runIf(hasDevice)('NoDataError', () => {
+    it('Device.poll() handles NoDataError without erroring out the device', async () => {
+      const handler = new WinixHandler(storagePath, ENCRYPTION_KEY);
+      await handler.login(USERNAME!, PASSWORD!);
+
+      const client = new WinixClient(handler.getIdentityId());
+
+      // Plausible-but-unregistered deviceId. initialFetch soft-fails (no throw),
+      // poll() catches NoDataError and skips failure counter.
+      const ghostDevice = new Device('CCCCCCCCCCCC_xxxxxxxxxx', 2_000, log, client);
+      try {
+        await ghostDevice.initialFetch();
+        ghostDevice.startPolling(() => {});
+        await new Promise(r => setTimeout(r, 6_000));
+      } finally {
+        ghostDevice.stopPolling();
+      }
+
+      expect(ghostDevice.hasData()).toBe(false);
+    }, 30_000);
+  });
+
+  describe('MobileSessionInvalidError', () => {
+    it('handler.getDevices() recovers via re-login after mobile session invalidation', async () => {
+      const handler = new WinixHandler(storagePath, ENCRYPTION_KEY);
+      await handler.login(USERNAME!, PASSWORD!);
+
+      const baseline = await handler.getDevices();
+      expect(baseline.length).toBeGreaterThan(0);
+
+      // Invalidate the handler's mobile session by logging in elsewhere
+      await new Promise(r => setTimeout(r, 2000));
+      await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+
+      // getDevices should auto-recover via internal re-login
+      const recovered = await handler.getDevices();
+      expect(recovered.length).toBeGreaterThan(0);
+    }, 60_000);
+
+    it('throttle: second invalidation within 5 minutes bubbles MobileSessionInvalidError', async () => {
+      const handler = new WinixHandler(storagePath, ENCRYPTION_KEY);
+      await handler.login(USERNAME!, PASSWORD!);
+
+      // First invalidation + recovery (consumes throttle slot)
+      await new Promise(r => setTimeout(r, 2000));
+      await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+      await handler.getDevices();
+
+      // Immediately invalidate again — re-login should be throttled, error bubbles
+      await new Promise(r => setTimeout(r, 2000));
+      await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+
+      await expect(handler.getDevices()).rejects.toBeInstanceOf(MobileSessionInvalidError);
+    }, 90_000);
+  });
+});

--- a/tests/winix.test.ts
+++ b/tests/winix.test.ts
@@ -1,4 +1,11 @@
-import { RefreshTokenExpiredError, WinixAccount, WinixAuth, WinixAuthResponse, WinixDevice } from 'winix-api';
+import {
+  MobileSessionInvalidError,
+  RefreshTokenExpiredError,
+  WinixAccount,
+  WinixAuth,
+  WinixAuthResponse,
+  WinixDevice,
+} from 'winix-api';
 import { NotConfiguredError, UnauthenticatedError, WinixHandler } from '../src/winix';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
@@ -186,6 +193,39 @@ describe('WinixHandler', () => {
 
       expect(handler.login).toHaveBeenCalledWith(mockAuth.username, mockAuth.password);
       expect(devices).toEqual(mockDevices);
+    });
+
+    it('should handle MobileSessionInvalidError and re-login', async () => {
+      handler['auth'] = mockAuth;
+      const sessionErr = new MobileSessionInvalidError('400', 'The user is not valid.', 400, 'https://example');
+      handler['winix'] = {
+        getDevices: vi.fn().mockRejectedValueOnce(sessionErr).mockResolvedValue(mockDevices),
+      } as unknown as WinixAccount;
+
+      vi.spyOn(handler, 'login').mockResolvedValue(mockAuth);
+
+      const devices = await handler.getDevices();
+
+      expect(handler.login).toHaveBeenCalledWith(mockAuth.username, mockAuth.password);
+      expect(devices).toEqual(mockDevices);
+    });
+
+    it('should throttle MobileSessionInvalidError re-logins to one per 5 minutes', async () => {
+      handler['auth'] = mockAuth;
+      const sessionErr = new MobileSessionInvalidError('400', 'The user is not valid.', 400, 'https://example');
+      handler['winix'] = {
+        getDevices: vi.fn().mockRejectedValue(sessionErr),
+      } as unknown as WinixAccount;
+
+      vi.spyOn(handler, 'login').mockResolvedValue(mockAuth);
+
+      // First call: re-login attempted, then second getDevices throws and bubbles
+      await expect(handler.getDevices()).rejects.toBeInstanceOf(MobileSessionInvalidError);
+      expect(handler.login).toHaveBeenCalledTimes(1);
+
+      // Second call right after: throttled, no additional login attempt
+      await expect(handler.getDevices()).rejects.toBeInstanceOf(MobileSessionInvalidError);
+      expect(handler.login).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3563,10 +3563,10 @@ why-is-node-running@^2.3.0:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-winix-api@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/winix-api/-/winix-api-2.0.0.tgz#dce9ce22083a44615ab9430494728d4ffe267186"
-  integrity sha512-3oaV3X89Ul93rQePDiTXdFzJ4j/4vbTenaaltr5kGsppAQuByj/YMUqxpYN0KSN5zNDuRfhola8CUhx0GWK2jg==
+winix-api@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/winix-api/-/winix-api-2.0.1.tgz#2cf8573c07adf4b2c448ddec28717f63a555afed"
+  integrity sha512-bcSY5HgLCxpvEa/z6syUejDOfwSMj1nKhUt+qaa77yVURrh+lUuXUS4UK/uewuWrWtQX2y0LRxNpBNojvyS6HA==
   dependencies:
     "@aws-sdk/client-cognito-identity" "3.1014.0"
     "@aws-sdk/client-cognito-identity-provider" "3.1014.0"


### PR DESCRIPTION
Related to #43

## Summary
- `Device.poll()` catches `NoDataError`, retains last-known state, does not increment `consecutiveFailures` (no flip to "Not Responding" in HomeKit)
- `WinixHandler.getDevices()` catches `MobileSessionInvalidError`, re-logs in once and retries, with a 5-minute throttle to prevent ping-pong with another active session
- Poll error log now includes the error class name for easier diagnosis next time something falls through

## Problem
Issue #43: HomeKit shows devices as "Not Responding" intermittently; restarting Homebridge fixes it. Two distinct Winix backend behaviors were both surfacing as plain errors with no recovery path:

1. Winix occasionally returns `resultMessage: "no data"` for a healthy registered device. The plugin treated this as a hard comm failure; after 3 in a row, `isReachable()` flipped false and HomeKit showed -70402.
2. Logging in twice with the same credentials (mobile app + plugin, or two plugin instances) invalidates the first instance's mobile session. The next `getDevices()` would fail with `HTTP 400 / "user is not valid"` and never recover until restart. Note: the control plane (`getDeviceStatus`) survives this, so steady-state polling is unaffected — this only bites at startup or during the periodic device-list refresh.

## Fix
Uses the new typed errors from winix-api 2.0.1:

- `Device.poll()` adds an `instanceof NoDataError` branch before the generic failure path. Schedules the next poll at the normal interval, retains `state`, leaves `consecutiveFailures` alone.
- `WinixHandler.getDevices()` adds an `instanceof MobileSessionInvalidError` branch alongside the existing `RefreshTokenExpiredError` recovery. Calls `login()` and retries `getDevices()`. A 5-minute `lastReloginAt` throttle prevents loop-bombs if the user has another active session continuously invalidating ours.
- Poll error log now prefixes `error.constructor.name`.

## Why
Mirrors the existing `RefreshTokenExpiredError` recovery pattern. iprak/winix (Home Assistant integration) has handled both of these the same way for years (no-data → return empty/retain, 900/400 → re-auth) and it's stable there. The throttle is the one thing they don't have, but with two instances in play (a phone + the plugin) we'd otherwise loop forever.

## Test Plan
- New unit tests in `tests/device.test.ts` (NoDataError) and `tests/winix.test.ts` (MobileSessionInvalidError + throttle)
- New integration test file `tests/integration/integration-session-recovery.test.ts` (run via `yarn test:integration:session-recovery`) hitting the live Winix API to verify:
  - poll() handles NoDataError end-to-end
  - getDevices() auto-recovers from a real mobile-session invalidation triggered by a second login
  - the throttle: a second invalidation immediately after the first bubbles `MobileSessionInvalidError` instead of re-logging
- **Warning**: the integration tests invalidate any active Winix mobile-app session for the test account.