### PR TITLE
fix: handle transient upstream errors and close post-restart unreachable window

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   ],
   "dependencies": {
     "@homebridge/plugin-ui-utils": "1.0.3",
-    "winix-api": "2.0.1"
+    "winix-api": "2.0.2"
   },
   "devDependencies": {
     "@types/node": "20.11.0",

--- a/src/characteristic.ts
+++ b/src/characteristic.ts
@@ -7,6 +7,7 @@ import {
   Service,
   WithUUID,
 } from 'homebridge';
+import { RateLimitError, UpstreamUnavailableError } from 'winix-api';
 import { WinixPurifierPlatform } from './platform';
 import { DeviceLogger } from './logger';
 import { assertError } from './errors';
@@ -83,7 +84,14 @@ export class CharacteristicWrapper {
       return await fn();
     } catch (e) {
       assertError(e);
-      this.log.error('error calling Winix API:', e.message);
+      // Known transient upstream conditions (rate limit, 5xx, DNS, malformed body)
+      // still fail the HAP call so HomeKit knows the action didn't land, but log at
+      // warn without the implication of a plugin bug.
+      if (e instanceof RateLimitError || e instanceof UpstreamUnavailableError) {
+        this.log.warn(`Winix API transient: ${e.constructor.name}: ${e.message}`);
+      } else {
+        this.log.error('error calling Winix API:', e.message);
+      }
       throw new this.platform.HapStatusError(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
     }
   }

--- a/src/device.ts
+++ b/src/device.ts
@@ -16,6 +16,8 @@ export interface DeviceState extends DeviceStatus {
 const MAX_BACKOFF_MS = 5 * 60 * 1000;
 const COMMAND_DELAY_MS = 1500;
 const UNREACHABLE_THRESHOLD = 3;
+// 90s clears WinixClient's internal 60s rate-limit cooldown plus a small buffer,
+// so the first poll after a rate-limited initialFetch actually has a chance to succeed.
 const FAILED_FETCH_RETRY_MS = 90 * 1000;
 
 export class Device {

--- a/src/device.ts
+++ b/src/device.ts
@@ -1,4 +1,7 @@
-import { Airflow, AirQuality, DeviceStatus, Mode, NoDataError, Plasmawave, Power, RateLimitError, WinixClient } from 'winix-api';
+import {
+  Airflow, AirQuality, DeviceStatus, Mode, NoDataError, Plasmawave, Power,
+  RateLimitError, UpstreamUnavailableError, WinixClient,
+} from 'winix-api';
 import { DeviceLogger } from './logger';
 
 export interface DeviceState extends DeviceStatus {
@@ -13,6 +16,7 @@ export interface DeviceState extends DeviceStatus {
 const MAX_BACKOFF_MS = 5 * 60 * 1000;
 const COMMAND_DELAY_MS = 1500;
 const UNREACHABLE_THRESHOLD = 3;
+const FAILED_FETCH_RETRY_MS = 90 * 1000;
 
 export class Device {
 
@@ -56,8 +60,8 @@ export class Device {
       this.consecutiveFailures = 0;
       this.log.debug('device:initialFetch()', JSON.stringify(this.state));
     } catch (e: unknown) {
-      if (e instanceof RateLimitError) {
-        this.log.warn('device:initialFetch() rate limited, using defaults');
+      if (e instanceof RateLimitError || e instanceof UpstreamUnavailableError) {
+        this.log.warn(`device:initialFetch() ${e.constructor.name}, using defaults (will retry soon)`);
         return;
       }
       this.log.warn('device:initialFetch() failed, using defaults:', (e as Error).message);
@@ -66,10 +70,14 @@ export class Device {
 
   startPolling(onUpdate: () => void): void {
     this.onUpdate = onUpdate;
-    // Stagger the first poll with a random delay to avoid all devices
-    // hitting the API at the same time
-    const jitter = Math.floor(Math.random() * this.pollIntervalMs);
-    this.schedulePoll(jitter);
+    // If initialFetch failed (rate limited, upstream unavailable, etc.), the device
+    // is unreachable in HomeKit until the first successful poll. Skip the full-interval
+    // jitter and retry soon to close that window. Otherwise stagger the first poll
+    // with a random delay to avoid all devices hitting the API at the same time.
+    const delay = this.hasReceivedData
+      ? Math.floor(Math.random() * this.pollIntervalMs)
+      : Math.min(FAILED_FETCH_RETRY_MS, this.pollIntervalMs);
+    this.schedulePoll(delay);
   }
 
   resetPollTimer(delayMs = 3000): void {
@@ -210,10 +218,10 @@ export class Device {
         this.schedulePoll(this.pollIntervalMs);
         return;
       }
-      // Winix occasionally returns "no data" for a healthy device. Treat as
-      // transient: keep last-known state and don't count toward unreachable.
-      if (e instanceof NoDataError) {
-        this.log.debug('device:poll() got NoDataError, retaining last-known state');
+      // Transient upstream conditions (Winix "no data", 5xx, DNS/connect failures,
+      // malformed bodies). Keep last-known state and don't count toward unreachable.
+      if (e instanceof NoDataError || e instanceof UpstreamUnavailableError) {
+        this.log.debug(`device:poll() ${e.constructor.name}, retaining last-known state`);
         this.schedulePoll(this.pollIntervalMs);
         return;
       }

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Airflow, AirQuality, Mode, NoDataError, Plasmawave, Power, WinixClient, RateLimitError } from 'winix-api';
+import {
+  Airflow, AirQuality, Mode, NoDataError, Plasmawave, Power,
+  RateLimitError, UpstreamUnavailableError, WinixClient,
+} from 'winix-api';
 import { Device } from '../src/device';
 
 vi.mock('winix-api', async () => {
@@ -25,6 +28,13 @@ vi.mock('winix-api', async () => {
     }
   }
 
+  class UpstreamUnavailableError extends Error {
+    constructor(public readonly cause: string) {
+      super(`Winix backend unavailable: ${cause}`);
+      this.name = 'UpstreamUnavailableError';
+    }
+  }
+
   const WinixClient = vi.fn().mockImplementation(() => ({
     getDeviceStatus: vi.fn(),
     setPower: vi.fn(),
@@ -33,7 +43,7 @@ vi.mock('winix-api', async () => {
     setPlasmawave: vi.fn(),
   }));
 
-  return { ...enums, WinixClient, RateLimitError, NoDataError };
+  return { ...enums, WinixClient, RateLimitError, NoDataError, UpstreamUnavailableError };
 });
 
 const mockLog = {
@@ -579,7 +589,7 @@ describe('Device', () => {
 
       expect(device.hasData()).toBe(false);
       expect(device.getPower()).toBe(Power.Off);
-      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('rate limited'));
+      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('RateLimitError'));
     });
 
     it('should throw RateLimitError on SET commands during rate limit', async () => {
@@ -628,6 +638,108 @@ describe('Device', () => {
       // Last-known state retained
       expect(device.getPower()).toBe(Power.On);
       expect(device.getAirflow()).toBe(Airflow.High);
+    });
+  });
+
+  describe('UpstreamUnavailableError handling', () => {
+    it('should not increment consecutiveFailures on UpstreamUnavailableError during poll', async () => {
+      vi.mocked(client.getDeviceStatus).mockResolvedValue(mockStatus);
+      await device.initialFetch();
+      expect(device.isReachable()).toBe(true);
+
+      vi.mocked(client.getDeviceStatus).mockRejectedValue(new UpstreamUnavailableError('HTTP 504'));
+      device.startPolling(vi.fn());
+
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      }
+
+      expect(device.isReachable()).toBe(true);
+    });
+
+    it('should retain last-known state across UpstreamUnavailableError polls', async () => {
+      vi.mocked(client.getDeviceStatus).mockResolvedValue({
+        ...mockStatus,
+        power: Power.On,
+        airflow: Airflow.High,
+      });
+      await device.initialFetch();
+
+      vi.mocked(client.getDeviceStatus).mockRejectedValue(new UpstreamUnavailableError('EAI_AGAIN'));
+      device.startPolling(vi.fn());
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+      expect(device.getPower()).toBe(Power.On);
+      expect(device.getAirflow()).toBe(Airflow.High);
+    });
+
+    it('should handle UpstreamUnavailableError during initialFetch gracefully', async () => {
+      vi.mocked(client.getDeviceStatus).mockRejectedValue(new UpstreamUnavailableError('HTTP 504'));
+      await device.initialFetch();
+
+      expect(device.hasData()).toBe(false);
+      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('UpstreamUnavailableError'));
+    });
+  });
+
+  describe('startPolling first-poll timing', () => {
+    // Use a longer poll interval than the 90s failed-fetch retry so the two branches
+    // are observably different. The default POLL_INTERVAL_MS (30s) is shorter than
+    // the retry window and would mask the behavior.
+    const LONG_POLL_MS = 5 * 60 * 1000;
+    let longDevice: Device;
+
+    beforeEach(() => {
+      longDevice = new Device(DEVICE_ID, LONG_POLL_MS, mockLog, client);
+    });
+
+    afterEach(() => {
+      longDevice.stopPolling();
+    });
+
+    it('uses full-interval jitter when initialFetch succeeded', async () => {
+      // Pin jitter to the high end so we can assert it does NOT fire early
+      vi.spyOn(Math, 'random').mockReturnValue(0.99);
+
+      vi.mocked(client.getDeviceStatus).mockResolvedValue(mockStatus);
+      await longDevice.initialFetch();
+      expect(longDevice.hasData()).toBe(true);
+
+      vi.mocked(client.getDeviceStatus).mockClear();
+      longDevice.startPolling(vi.fn());
+
+      // 90s in: poll should NOT have fired yet (jitter is ~297s)
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(client.getDeviceStatus).not.toHaveBeenCalled();
+    });
+
+    it('retries quickly after a rate-limited initialFetch (within 90s, not full interval)', async () => {
+      vi.mocked(client.getDeviceStatus).mockRejectedValue(new RateLimitError());
+      await longDevice.initialFetch();
+      expect(longDevice.hasData()).toBe(false);
+
+      vi.mocked(client.getDeviceStatus).mockClear();
+      vi.mocked(client.getDeviceStatus).mockResolvedValue(mockStatus);
+      longDevice.startPolling(vi.fn());
+
+      // Should fire within ~90s, well before the 5min interval jitter would have ended
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(client.getDeviceStatus).toHaveBeenCalledTimes(1);
+      expect(longDevice.hasData()).toBe(true);
+    });
+
+    it('retries quickly after UpstreamUnavailableError during initialFetch', async () => {
+      vi.mocked(client.getDeviceStatus).mockRejectedValue(new UpstreamUnavailableError('HTTP 504'));
+      await longDevice.initialFetch();
+      expect(longDevice.hasData()).toBe(false);
+
+      vi.mocked(client.getDeviceStatus).mockClear();
+      vi.mocked(client.getDeviceStatus).mockResolvedValue(mockStatus);
+      longDevice.startPolling(vi.fn());
+
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(client.getDeviceStatus).toHaveBeenCalledTimes(1);
+      expect(longDevice.hasData()).toBe(true);
     });
   });
 });

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -589,7 +589,8 @@ describe('Device', () => {
 
       expect(device.hasData()).toBe(false);
       expect(device.getPower()).toBe(Power.Off);
-      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('RateLimitError'));
+      // Regex tolerates vitest's mock-class name suffix (e.g. RateLimitError2)
+      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringMatching(/RateLimitError\d*, using defaults/));
     });
 
     it('should throw RateLimitError on SET commands during rate limit', async () => {
@@ -678,7 +679,7 @@ describe('Device', () => {
       await device.initialFetch();
 
       expect(device.hasData()).toBe(false);
-      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('UpstreamUnavailableError'));
+      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringMatching(/UpstreamUnavailableError\d*, using defaults/));
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3563,10 +3563,10 @@ why-is-node-running@^2.3.0:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-winix-api@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/winix-api/-/winix-api-2.0.1.tgz#2cf8573c07adf4b2c448ddec28717f63a555afed"
-  integrity sha512-bcSY5HgLCxpvEa/z6syUejDOfwSMj1nKhUt+qaa77yVURrh+lUuXUS4UK/uewuWrWtQX2y0LRxNpBNojvyS6HA==
+winix-api@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/winix-api/-/winix-api-2.0.2.tgz#c6c0912ab2351ae63288e5136f90ce7be4d621e1"
+  integrity sha512-3NN3ir7qnCoa3UTPyKC1BUlXl7N01Q/RBAucn1MFljjNSc+5iSSzp25xfHPNrNhg3bFY/H6vaiBog/EHU+9yfg==
   dependencies:
     "@aws-sdk/client-cognito-identity" "3.1014.0"
     "@aws-sdk/client-cognito-identity-provider" "3.1014.0"


### PR DESCRIPTION
Related to #43.

## Summary
- Bumps `winix-api` to `2.0.2` to consume the new `UpstreamUnavailableError` typed error
- `Device.poll()` and `Device.initialFetch()` now treat `UpstreamUnavailableError` (Winix 5xx, DNS/connect failures, malformed bodies) identically to `NoDataError`: retain last-known state, do not flip the device to "Not Responding"
- `startPolling()` short-circuits the first-poll jitter (up to one full interval) to `~90s` when `initialFetch` failed, closing the window where HomeKit shows `-70402` after a rate-limited or upstream-unavailable startup
- Characteristic getter/setter wrap now logs known transient errors at `warn` instead of `error` (HAP error still bubbles so the user sees command failures)

## Problem
The user on #43 reported a second wave of issues after v2.2.5 shipped, during a period when Winix's backend was unhealthy (their mobile app was also slow/unresponsive):

1. `TypeError: Cannot read properties of undefined (reading 'resultMessage')` from `winix-api` when Winix returned a 2xx with a malformed/non-JSON body
2. `AxiosError: Request failed with status code 504` from `setAirflow`
3. `AxiosError: getaddrinfo EAI_AGAIN us.api.winix-iot.com`
4. A wall of HAP `-70402` errors immediately after a homebridge restart, because `initialFetch()` got rate limited, `hasReceivedData` stayed `false`, and `isReachable()` stayed `false` until the next poll fired (up to 5 minutes with the user's `pollIntervalSeconds: 300` config)

(1)–(3) all surfaced as generic errors with no recovery path; `Device.poll()` incremented `consecutiveFailures` and after 3 in a row the device went unreachable. (4) was a wholly separate gap in the restart path.

## Fix
`winix-api@2.0.2` (PR regaw-leinad/winix-api#14) categorizes (1)–(3) as a new typed `UpstreamUnavailableError`. This PR consumes it:

- `Device.poll()` transient branch now matches `NoDataError` OR `UpstreamUnavailableError`: retain `state`, leave `consecutiveFailures` alone, schedule next poll at the normal interval. Log message includes the error class name.
- `Device.initialFetch()` rate-limit branch extended to also catch `UpstreamUnavailableError` with the same fallback-to-defaults behavior.
- `startPolling()` picks `Math.min(90_000ms, pollIntervalMs)` for the first poll when `hasReceivedData` is false, so the post-restart `-70402` window collapses from "up to one poll interval" to "~90 seconds". 90s clears the `WinixClient` internal 60s cooldown plus a small buffer. Successful `initialFetch` is unchanged (full jittered interval).
- `CharacteristicWrapper.wrap()` logs `RateLimitError` and `UpstreamUnavailableError` at `warn` with the class name and message. The HAP `SERVICE_COMMUNICATION_FAILURE` still throws so HomeKit (and the user) sees that the action didn't land.

## Why
- Mirrors the existing `NoDataError` recovery pattern landed in v2.2.5 / #44.
- The root cause of (1)–(3) is upstream (Winix backend health) and not fixable in this plugin. Typed transients let us keep HomeKit happy while Winix is flaky.
- Setters intentionally still bubble the HAP error. Silently swallowing a control command failure would be worse than a visible one.
- The 90s value is the smallest delay that reliably clears the WinixClient cooldown without polling Winix more aggressively than necessary.

## Test Plan
- New `UpstreamUnavailableError handling` suite mirrors the existing `NoDataError` and `RateLimitError` suites: poll-loop with consecutive transient errors does not flip the device unreachable, state is retained, `initialFetch` falls back to defaults with the new warn message.
- New `startPolling first-poll timing` suite verifies all three branches:
  - Successful `initialFetch` uses full-interval jitter (poll does NOT fire within 90s when jitter is pinned to the high end)
  - Rate-limited `initialFetch` → first poll fires within 90s
  - Upstream-unavailable `initialFetch` → first poll fires within 90s
- All 80 unit tests pass; `yarn lint` clean.