### PR TITLE
fix: align integration test assertion with new initialFetch warning wording

### DIFF
--- a/tests/integration/integration-rate-limit.test.ts
+++ b/tests/integration/integration-rate-limit.test.ts
@@ -97,7 +97,7 @@ describe.runIf(canRun)('rate limiting integration', () => {
 
     expect(device.hasData()).toBe(false);
     expect(device.getPower()).toBe(Power.Off);
-    expect(hasMessageContaining('warn', 'rate limited')).toBe(true);
+    expect(hasMessageContaining('warn', 'RateLimitError')).toBe(true);
   }, 15_000);
 
   it('should throw RateLimitError on SET command without changing state', async () => {


### PR DESCRIPTION
### Summary
- Update `integration-rate-limit.test.ts:100` to match the new `initialFetch` warning text.

### Problem
The nightly Integration Tests workflow failed on 2026-05-14 with:

```
AssertionError: expected false to be true
 expect(hasMessageContaining('warn', 'rate limited')).toBe(true);
```

PR #45 reworded the `Device.initialFetch()` rate-limit warning from
`"device:initialFetch() rate limited, using defaults"` to
`"device:initialFetch() RateLimitError, using defaults (will retry soon)"`,
so the test's case-sensitive substring check for `"rate limited"` no longer matches.

PR #45 updated the corresponding unit test assertions but missed this integration assertion. The integration suite only runs on a nightly schedule, so the regression didn't surface in PR CI.

### Fix
Change the assertion to look for `"RateLimitError"`, which is what `${e.constructor.name}` now emits.

### Why
Runtime behavior is unchanged. `initialFetch()` still catches `RateLimitError`, falls back to defaults, and logs a warning. Only the log text shifted. The poll-path assertion on line 147 (`"rate limited"`) still matches its source string in `device.ts:219`, so no other test changes are needed.