### PR TITLE
fix: poll for initial data in rate-limit recovery test to deflake

### DIFF
--- a/tests/integration/integration-rate-limit.test.ts
+++ b/tests/integration/integration-rate-limit.test.ts
@@ -128,8 +128,18 @@ describe.runIf(canRun)('rate limiting integration', () => {
     console.log('Waiting for API to recover from earlier tests...');
     await waitForRecovery(probeClient, DEVICE_ID!);
 
-    // Step 2: Successful fetch so device has data and is reachable
-    await device.initialFetch();
+    // Step 2: Fetch until the device has data and is reachable.
+    // initialFetch() intentionally swallows a RateLimitError and leaves the
+    // device without data (see Device.initialFetch). The probe above confirmed
+    // recovery, but WAF can re-throttle between the probe and this fetch, so
+    // poll instead of assuming a single fetch succeeds.
+    const fetchDeadline = Date.now() + 60_000;
+    while (!device.hasData() && Date.now() < fetchDeadline) {
+      await device.initialFetch();
+      if (!device.hasData()) {
+        await new Promise(r => setTimeout(r, 5_000));
+      }
+    }
     expect(device.hasData()).toBe(true);
     expect(device.isReachable()).toBe(true);
 


### PR DESCRIPTION
### Summary
- Step 2 of the "stay reachable during rate limit and recover" integration test now polls `initialFetch()` until the device has data, instead of asserting after a single fetch.

### Problem
The **Integration Tests** workflow ([run](https://github.com/regaw-leinad/homebridge-winix-purifiers/actions/runs/27124785964)) fails intermittently in `integration-rate-limit.test.ts`:

```
should stay reachable during rate limit and recover after cooldown
AssertionError: expected false to be true
  tests/integration/integration-rate-limit.test.ts:133:30
    132| await device.initialFetch();
    133| expect(device.hasData()).toBe(true);
```

This is a flaky test, not a product bug. `Device.initialFetch()` intentionally swallows a `RateLimitError`/`UpstreamUnavailableError`, logs a warning, and leaves the device without data so the first poll retries. The test's Step 2 assumed a single `initialFetch()` always succeeds, but the test runs against the live Winix API behind AWS WAF: `waitForRecovery()` confirms recovery with a separate probe client, yet WAF can re-throttle in the gap before `device.initialFetch()` runs, so the fetch is dropped and `hasData()` stays `false`.

### Fix
Replace the one-shot fetch with a bounded poll (up to 60s) that retries `initialFetch()` until `hasData()` is true, then assert.

### Why
This mirrors the "poll, don't guess" approach the rest of this test already uses (`waitForRecovery`, the recovery loop in Step 5) and tolerates the unpredictable WAF timing instead of racing it. It does not weaken the assertion: the device must still end up with data and be reachable; it just stops failing on transient re-throttling. Unit suite (80 tests) still passes.