### PR TITLE
fix: handle errors from debounced speed sets without blocking the HAP handler

### DIFF
--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -5,6 +5,7 @@ import { DeviceOverride, WinixPlatformConfig } from './config';
 import { CharacteristicManager } from './characteristic';
 import { DeviceLogger } from './logger';
 import { Device } from './device';
+import { debounce, inBackground } from './debounce';
 
 /**
  * The maximum filter life in hours.
@@ -75,9 +76,15 @@ export class WinixPurifierAccessory {
     characteristics.get(this.purifier, this.Characteristic.TargetAirPurifierState)
       .onGet(this.getTargetState.bind(this))
       .onSet(this.setTargetState.bind(this));
+    // The airflow write can outlast HAP's 3s warning and 10s timeout when it has to
+    // switch mode first, so this handler returns without waiting. Failures are logged
+    // and the fast-forwarded poll resyncs HomeKit to the device's real state.
     characteristics.get(this.purifier, this.Characteristic.RotationSpeed)
       .onGet(this.getRotationSpeed.bind(this))
-      .onSet(this.debounce(this.setRotationSpeed.bind(this), 500));
+      .onSet(inBackground(
+        debounce(this.setRotationSpeed.bind(this), 500),
+        e => this.onBackgroundSetError('rotation speed', e),
+      ));
     characteristics.get(this.purifier, this.Characteristic.FilterLifeLevel)
       .onGet(this.getFilterLifeLevel.bind(this));
     characteristics.get(this.purifier, this.Characteristic.FilterChangeIndication)
@@ -229,6 +236,16 @@ export class WinixPurifierAccessory {
     const airflow = this.device.getAirflow();
     this.log.debug('accessory:getRotationSpeed()', airflow);
     return this.toRotationSpeed(airflow);
+  }
+
+  /**
+   * Handle a set that ran in the background, past the point where its error could be
+   * returned to HomeKit. Resync so the UI falls back to the device's real state
+   * instead of showing a value that never landed.
+   */
+  onBackgroundSetError(what: string, e: unknown): void {
+    this.log.error(`error setting ${what}:`, e instanceof Error ? e.message : String(e));
+    this.device.resetPollTimer();
   }
 
   async setRotationSpeed(state: CharacteristicValue): Promise<void> {
@@ -496,13 +513,4 @@ export class WinixPurifierAccessory {
     return Math.max(ambientLight, MIN_AMBIENT_LIGHT);
   }
 
-  private debounce(func: (arg: CharacteristicValue) => Promise<void>, delay: number): (arg: CharacteristicValue) => Promise<void> {
-    let timeoutId: NodeJS.Timeout | null = null;
-    return async (arg: CharacteristicValue) => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      timeoutId = setTimeout(async () => await func(arg), delay);
-    };
-  }
 }

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,0 +1,49 @@
+import { CharacteristicValue } from 'homebridge';
+
+/**
+ * Run a set handler without waiting for it. HAP warns when a handler takes over 3s and
+ * returns a timeout to HomeKit at 10s, so handlers whose work can outlast that must
+ * return immediately. The rejection still has to go somewhere: onError receives it, so
+ * it never becomes an unhandled promise rejection.
+ */
+export function inBackground(
+  func: (arg: CharacteristicValue) => Promise<void>,
+  onError: (e: unknown) => void,
+): (arg: CharacteristicValue) => Promise<void> {
+  return async (arg: CharacteristicValue) => {
+    func(arg).catch(onError);
+  };
+}
+
+/**
+ * Debounce a set handler, coalescing rapid calls into a single invocation with the
+ * latest value. Every coalesced caller settles on the outcome of that one
+ * invocation, so a failed write still reaches CharacteristicWrapper and becomes a
+ * HAP error. Resolving early instead would strand the rejection as an unhandled
+ * promise rejection, which can take down the Homebridge process.
+ */
+export function debounce(
+  func: (arg: CharacteristicValue) => Promise<void>,
+  delay: number,
+): (arg: CharacteristicValue) => Promise<void> {
+  let timeoutId: NodeJS.Timeout | null = null;
+  let waiters: { resolve: () => void; reject: (reason: unknown) => void }[] = [];
+
+  return (arg: CharacteristicValue) => new Promise<void>((resolve, reject) => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    waiters.push({ resolve, reject });
+
+    timeoutId = setTimeout(() => {
+      timeoutId = null;
+      const settling = waiters;
+      waiters = [];
+
+      func(arg).then(
+        () => settling.forEach(w => w.resolve()),
+        (e: unknown) => settling.forEach(w => w.reject(e)),
+      );
+    }, delay);
+  });
+}

--- a/tests/debounce.test.ts
+++ b/tests/debounce.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { debounce, inBackground } from '../src/debounce';
+
+describe('debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('invokes the wrapped function once with the latest value', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const debounced = debounce(fn, 500);
+
+    const calls = [debounced(25), debounced(50), debounced(75)];
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.all(calls);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(75);
+  });
+
+  it('does not invoke before the delay elapses', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const debounced = debounce(fn, 500);
+
+    void debounced(25);
+    await vi.advanceTimersByTimeAsync(499);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('resolves only after the wrapped function completes', async () => {
+    let release: () => void = () => undefined;
+    const fn = vi.fn().mockReturnValue(new Promise<void>(r => {
+      release = r;
+    }));
+    const debounced = debounce(fn, 500);
+
+    let settled = false;
+    const call = debounced(75).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fn).toHaveBeenCalled();
+    expect(settled).toBe(false);
+
+    release();
+    await call;
+    expect(settled).toBe(true);
+  });
+
+  // Regression: the old implementation resolved immediately and ran the write inside
+  // setTimeout, so a rejection never reached the caller and surfaced as an unhandled
+  // promise rejection instead of a HAP error.
+  it('rejects the caller when the wrapped function rejects', async () => {
+    const error = new Error('rate limited');
+    const fn = vi.fn().mockRejectedValue(error);
+    const debounced = debounce(fn, 500);
+
+    const call = debounced(75);
+    const assertion = expect(call).rejects.toThrow('rate limited');
+    await vi.advanceTimersByTimeAsync(500);
+    await assertion;
+  });
+
+  it('rejects every coalesced caller when the single invocation rejects', async () => {
+    const error = new Error('boom');
+    const fn = vi.fn().mockRejectedValue(error);
+    const debounced = debounce(fn, 500);
+
+    const calls = [debounced(25), debounced(50), debounced(75)];
+    const assertions = Promise.all(calls.map(c => expect(c).rejects.toThrow('boom')));
+    await vi.advanceTimersByTimeAsync(500);
+    await assertions;
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a fresh batch after one settles', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const debounced = debounce(fn, 500);
+
+    const first = debounced(25);
+    await vi.advanceTimersByTimeAsync(500);
+    await first;
+
+    const second = debounced(75);
+    await vi.advanceTimersByTimeAsync(500);
+    await second;
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(1, 25);
+    expect(fn).toHaveBeenNthCalledWith(2, 75);
+  });
+});
+
+describe('inBackground', () => {
+  // HAP warns at 3s and times out at 10s, so the handler must not wait on the write.
+  it('returns before the wrapped function settles', async () => {
+    let settled = false;
+    const fn = vi.fn().mockImplementation(() => new Promise<void>(resolve => {
+      setTimeout(() => {
+        settled = true;
+        resolve();
+      }, 5_000);
+    }));
+
+    await inBackground(fn, () => undefined)(75);
+
+    expect(fn).toHaveBeenCalledWith(75);
+    expect(settled).toBe(false);
+  });
+
+  it('routes a rejection to onError instead of leaving it unhandled', async () => {
+    const error = new Error('rate limited');
+    const onError = vi.fn();
+
+    await inBackground(vi.fn().mockRejectedValue(error), onError)(75);
+    await Promise.resolve();
+
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  it('does not reject the caller when the wrapped function rejects', async () => {
+    const onError = vi.fn();
+    const handler = inBackground(vi.fn().mockRejectedValue(new Error('boom')), onError);
+
+    await expect(handler(75)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Summary
- Fixes an unhandled promise rejection on the `RotationSpeed` set path that can take down the Homebridge process
- Keeps the handler non-blocking, per HAP's 3s warning and 10s timeout on set handlers
- Extracts `debounce` and a new `inBackground` wrapper into `src/debounce.ts`, with 9 tests

### Problem
`RotationSpeed` is the only characteristic wrapped in `debounce`, and the wrapper resolves immediately while running the actual write inside `setTimeout`:

```ts
return async (arg: CharacteristicValue) => {
  if (timeoutId) {
    clearTimeout(timeoutId);
  }
  timeoutId = setTimeout(async () => await func(arg), delay);
};
```

Nothing is ever attached to the promise returned by `func(arg)`. When a speed change fails, typically a `RateLimitError` or a transient Winix 5xx, the rejection has no handler. Node's default is `--unhandled-rejections=throw`, so a Winix hiccup during a speed change can crash Homebridge. Extended stretches of Winix 500s and 504s are not hypothetical, which is how this surfaced.

`CharacteristicManager.wrapSet` awaits the handler to convert errors into `HAPStatus.SERVICE_COMMUNICATION_FAILURE`, but it has already returned by the time the write runs, so the failure is invisible to HomeKit as well.

### Fix
`debounce` settles on the outcome of the single invocation it triggers, so callers can observe success or failure.

`inBackground` wraps that for the HAP handler: it starts the debounced write, returns immediately, and routes any rejection to `onBackgroundSetError`, which logs it and calls `resetPollTimer()` so the fast-forwarded poll resyncs HomeKit to the device's real state.

### Why
HAP warns when a set handler takes over 3s ("This plugin slows down Homebridge...") and returns a timeout to HomeKit at 10s. Homebridge's guidance is to return immediately and report the result later via `updateValue`. The airflow write can approach that budget on its own, because setting speed from Auto has to switch mode first and wait out the device's command delay before the airflow write lands.

`RotationSpeed` is also the only setter in the plugin that returns instantly, and it is the control most likely to be dragged repeatedly, so blocking it would be the most visible place to introduce lag.

The plugin already has the machinery for the non-blocking pattern: every setter calls `resetPollTimer()`, which fast-forwards a poll that pushes true state back through `sendHomekitUpdate()`. A failed write therefore self-corrects within a few seconds. The tradeoff is that HomeKit sees the value revert rather than an explicit error, which is the cost Homebridge's docs accept in exchange for not blocking the bridge.

Keeping `debounce` and `inBackground` separate leaves coalescing and error routing independent, and avoids standing up full accessory mocks to test two self-contained helpers.

### Test Plan
The error-path tests fail against the original `debounce` implementation, confirming they cover the bug rather than restating the new code:

```
× resolves only after the wrapped function completes
× rejects the caller when the wrapped function rejects
× rejects every coalesced caller when the single invocation rejects
```

`inBackground` is covered for the properties that matter: it returns before the wrapped write settles, it forwards rejections to `onError`, and it never rejects its own caller.

Full suite 89/89.

References: [Characteristic Warnings](https://github.com/homebridge/homebridge/wiki/Characteristic-Warnings), [HAP-NodeJS v0.9.0](https://github.com/homebridge/HAP-NodeJS/releases/tag/v0.9.0) for the 3s and 10s thresholds.
